### PR TITLE
correct a mistake in obtainScriptAndStyle

### DIFF
--- a/lib/lang/html.js
+++ b/lib/lang/html.js
@@ -136,8 +136,8 @@ function obtainScriptAndStyle(content, resource, opts, host) {
 
       file ? resource.add(file.id, false, false, lattrs) : resource.addCss(href, lattrs);
       all = '';
-    } else if (style && body.trim()) {
-      resource.addCssEmbed(body, sattrs);
+    } else if (style && sbody.trim()) {
+      resource.addCssEmbed(sbody, sattrs);
       all = '';
     }
 


### PR DESCRIPTION
After combining obtainScript and obtainStyle blocks into obtainScriptAndStyle, 
last condition check should use sbody instead of body, which is content of script element.
## 

将obtainScript和obtainStyle合并到obtainScriptandStyle，函数最后的style处理应该使用sbody.
